### PR TITLE
Add Gemfile for local deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+gem "jekyll"
+gem 'jemoji'
+gem 'webrick'
+
+# gem "rails"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ This theme can be used just as other [Jekyll themes][1].
 
 [Fork][3] this repository and add your markdown posts to the `_posts` folder.
 
+### Deploy Locally with Jekyll Serve
+
+This theme can be ran locally using Ruby and Gemfiles.
+
+[Testing your GitHub Pages site locally with Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) - GitHub
+
 ## How to generate TOC
 
 The jekyll-gitbook theme leverages [jekyll-toc][4] to generate the *Contents* for the page.


### PR DESCRIPTION
Add a basic Gemfile to use Jekyll on your local machine to test the site before pushing to gh-pages or other production environments.

Instructions added to readme with link to more detailed instructions from Github.

If you have Ruby and all other dependencies installed, you can just run 

`bundle`

to install everything needed for the site, and then

`bundle exec jekyll serve`

to run the site locally at 

http://127.0.0.1:4000/jekyll-gitbook/
