### PR TITLE
Feature slightly enhanced social share support

### DIFF
--- a/_includes/gitbook-sharing.json.tpl
+++ b/_includes/gitbook-sharing.json.tpl
@@ -1,13 +1,28 @@
             "sharing": {
-                "all": ["facebook", "google", "twitter", "weibo", "instapaper", "github", "telegram"],
                 "facebook": true,
+
                 "google": false,
+
                 "github": true,
+              {% if site.github_username %}
+                "github_link": "https://github.com/{{ site.github_username }}",
+              {% else %}
                 "github_link": "https://github.com",
+              {% endif %}
+
                 "telegram": false,
                 "telegram_link": "https://t.me",
+
                 "instapaper": false,
+
                 "twitter": true,
+              {% if site.twitter_username %}
+                "twitter_link": "https://twitter.com/{{ site.twitter_username }}",
+              {% endif %}
+
                 "vk": false,
-                "weibo": false
+
+                "weibo": false,
+
+                "all": ["facebook", "google", "twitter", "weibo", "instapaper", "github", "telegram"]
             },

--- a/assets/gitbook/gitbook-plugin-sharing/buttons.js
+++ b/assets/gitbook/gitbook-plugin-sharing/buttons.js
@@ -96,17 +96,13 @@ require(['gitbook', 'jquery'], function(gitbook, $) {
             if (!opts[sideId]) return;
 
             var onClick = site.onClick;
-
-            if (sideId === "github" && opts["github_link"] !== undefined && opts["github_link"] !== "") {
+            
+            // override target link with provided link
+            var side_link = opts[`${sideId}_link`]
+            if (side_link !== undefined && side_link !== "") {
                 onClick = function(e) {
                     e.preventDefault();
-                    window.open(opts["github_link"]);
-                }
-            }
-            if (sideId === "telegram" && opts["telegram_link"] !== undefined && opts["telegram_link"] !== "") {
-                onClick = function(e) {
-                    e.preventDefault();
-                    window.open(opts["telegram_link"]);
+                    window.open(side_link);
                 }
             }
 


### PR DESCRIPTION
This change is compatible with current workings. 

It just expands the trick to slide in an over-ruling `{name}_link` for all the supported social platforms

Additionally, it generates those links for github and twitter based on the already provided config elements in the `_config.yml`

Hope you can consider.