### PR TITLE
Try to fix the expender such that only direct children are expanded

### DIFF
--- a/assets/gitbook/gitbook-plugin-expandable-chapters-small2/expandable-chapters-small.css
+++ b/assets/gitbook/gitbook-plugin-expandable-chapters-small2/expandable-chapters-small.css
@@ -4,7 +4,7 @@
 	max-height: 0px;
 }
 
-.book .book-summary .chapter li ul {
+.book .book-summary .chapter li > ul {
 	overflow: hidden;
 	max-height: 0px !important;
 }
@@ -14,7 +14,7 @@
 	max-height: 9999px;
 }
 
-.book .book-summary .chapter.expanded li.expanded ul {
+.book .book-summary .chapter.expanded li.expanded > ul {
 	max-height: 9999px !important;
 }
 


### PR DESCRIPTION
Fixes the case that 3rd or more level section expanders are always expanded regardless of the "expanded" CSS class