### PR TITLE
refactor: Update padding of info, warning, and danger blocks.

### DIFF
--- a/assets/gitbook/custom.css
+++ b/assets/gitbook/custom.css
@@ -177,30 +177,22 @@
     background-color: var(--c-tip-bg);
     color: var(--c-tip-text);
     font-family: var(--font-family);
+    padding: 10px;
 }
 
-.markdown-section blockquote.block-tip h1 {
-    color: var(--c-tip-title);
-}
-
-.markdown-section blockquote.block-tip h2 {
-    color: var(--c-tip-title);
-}
-
-.markdown-section blockquote.block-tip h3 {
-    color: var(--c-tip-title);
-}
-
-.markdown-section blockquote.block-tip h4 {
-    color: var(--c-tip-title);
-}
-
-.markdown-section blockquote.block-tip h5 {
-    color: var(--c-tip-title);
-}
-
+.markdown-section blockquote.block-tip h1,
+.markdown-section blockquote.block-tip h2,
+.markdown-section blockquote.block-tip h3,
+.markdown-section blockquote.block-tip h4,
+.markdown-section blockquote.block-tip h5,
 .markdown-section blockquote.block-tip h6 {
     color: var(--c-tip-title);
+    margin: 0px;
+    margin-bottom: 5px;
+}
+
+.markdown-section blockquote.block-tip p {
+    margin-bottom: 0px;
 }
 
 .markdown-section blockquote.block-warning {
@@ -208,30 +200,22 @@
     background-color: var(--c-warning-bg);
     color: var(--c-warning-text);
     font-family: var(--font-family);
+    padding: 10px;
 }
 
-.markdown-section blockquote.block-warning h1 {
-    color: var(--c-warning-title);
-}
-
-.markdown-section blockquote.block-warning h2 {
-    color: var(--c-warning-title);
-}
-
-.markdown-section blockquote.block-warning h3 {
-    color: var(--c-warning-title);
-}
-
-.markdown-section blockquote.block-warning h4 {
-    color: var(--c-warning-title);
-}
-
-.markdown-section blockquote.block-warning h5 {
-    color: var(--c-warning-title);
-}
-
+.markdown-section blockquote.block-warning h1,
+.markdown-section blockquote.block-warning h2,
+.markdown-section blockquote.block-warning h3,
+.markdown-section blockquote.block-warning h4,
+.markdown-section blockquote.block-warning h5,
 .markdown-section blockquote.block-warning h6 {
     color: var(--c-warning-title);
+    margin: 0px;
+    margin-bottom: 5px;
+}
+
+.markdown-section blockquote.block-warning p {
+    margin-bottom: 0px;
 }
 
 .markdown-section blockquote.block-danger {
@@ -239,30 +223,22 @@
     background-color: var(--c-danger-bg);
     color: var(--c-danger-text);
     font-family: var(--font-family);
+    padding: 10px;
 }
 
-.markdown-section blockquote.block-danger h1 {
-    color: var(--c-danger-title);
-}
-
-.markdown-section blockquote.block-danger h2 {
-    color: var(--c-danger-title);
-}
-
-.markdown-section blockquote.block-danger h3 {
-    color: var(--c-danger-title);
-}
-
-.markdown-section blockquote.block-danger h4 {
-    color: var(--c-danger-title);
-}
-
-.markdown-section blockquote.block-danger h5 {
-    color: var(--c-danger-title);
-}
-
+.markdown-section blockquote.block-danger h1,
+.markdown-section blockquote.block-danger h2,
+.markdown-section blockquote.block-danger h3,
+.markdown-section blockquote.block-danger h4,
+.markdown-section blockquote.block-danger h5,
 .markdown-section blockquote.block-danger h6 {
     color: var(--c-danger-title);
+    margin: 0px;
+    margin-bottom: 5px;
+}
+
+.markdown-section blockquote.block-danger p {
+    margin-bottom: 0px;
 }
 
 pre:has(code.language-mermaid[data-processed="true"]) {


### PR DESCRIPTION
This pull request changes the padding of info, warning, and danger blocks to match the style of other elements on the page. (Such as code blocks.)

Changes can be previewed at: https://jacobhumston.github.io/jekyll-gitbook/jekyll/2022-06-30-tips_warnings_dangers.html
![7c2goUuSz9](https://github.com/sighingnow/jekyll-gitbook/assets/57332486/496a0975-820f-4eef-94ba-6a796f936191)
