### PR TITLE
enable toc for index page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ remote_theme: sighingnow/jekyll-gitbook
 
 toc:
   enabled: true
+  enabled_index: false
   h_min: 1
   h_max: 3
 

--- a/_config.yml
+++ b/_config.yml
@@ -17,10 +17,10 @@ rss:              RSS
 remote_theme: sighingnow/jekyll-gitbook
 
 toc:
-  enabled: true
-  enabled_index: false
-  h_min: 1
-  h_max: 3
+  enabled:       true
+  enabled_index: true 
+  h_min:         1
+  h_max:         3
 
 # customize the link favicon in header, will be {{site.baseurl}}/{{site.favicon_path}}
 favicon_path:     /assets/gitbook/images/favicon.ico

--- a/_config.yml
+++ b/_config.yml
@@ -17,10 +17,9 @@ rss:              RSS
 remote_theme: sighingnow/jekyll-gitbook
 
 toc:
-  enabled:       true
-  enabled_index: true 
-  h_min:         1
-  h_max:         3
+  enabled: true
+  h_min:   1
+  h_max:   3
 
 # customize the link favicon in header, will be {{site.baseurl}}/{{site.favicon_path}}
 favicon_path:     /assets/gitbook/images/favicon.ico

--- a/_includes/toc-date.html
+++ b/_includes/toc-date.html
@@ -39,6 +39,11 @@
                 <a href="{{site.baseurl}}/" onclick="pageScrollToTop(this)">
                     {{ site.title | escape }}
                 </a>
+                {% if site.toc.enabled %}
+                    {% if page.url == "/" and site.toc.enabled_index %}
+                        {% include toc.html html=content h_min=site.toc.h_min h_max=site.toc.h_max %}
+                    {% endif %}
+                {% endif %}
             </li>
 
             <li class="divider"></li>

--- a/_includes/toc-date.html
+++ b/_includes/toc-date.html
@@ -40,7 +40,7 @@
                     {{ site.title | escape }}
                 </a>
                 {% if site.toc.enabled %}
-                    {% if page.url == "/" and site.toc.enabled_index %}
+                    {% if site.toc.enabled_index %}
                         {% include toc.html html=content h_min=site.toc.h_min h_max=site.toc.h_max %}
                     {% endif %}
                 {% endif %}


### PR DESCRIPTION
as mentioned in #136, I was interested in having table of contents enabled for the index page – and not just post pages.

this PR accomplishes that change.

by default, if the variable `toc.enabled_index` is not defined, then toc is not enabled. this ensures existing users aren't impacted.
