### PR TITLE
Possible Typo in _includes/footer.html Causing Improper JS Loading

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,7 @@
 <script src="{{site.baseurl}}/assets/gitbook/custom-local.js"></script>
 
 {% if site.extra_footer_js %}
-    {%- for extra_js in site.extra_header_js -%}
+    {%- for extra_js in site.extra_footer_js -%}
         {%- assign starts_with = extra_js | slice: 0,4  -%}
         {% if starts_with == "http" %}
 <script src="{{ extra_js }}"></script>


### PR DESCRIPTION
## Issue Description

The code under `{% if site.extra_footer_js %}` incorrectly references `{%- for extra_js in site.extra_header_js -%}` instead of `{%- for extra_js in site.extra_footer_js -%}`

### Caused Result
This issue may prevent the footer scripts from loading, but executing those intended for the header.

## Disclaimer (?)

It's my first time to make an open PR or issue... Hopefully it's an real issue and I didn't use an awful format. I'm open to feedback on formatting and approach, and if anything wrong, please forgive me. QAQ