### PR TITLE
Fix inaccessible settings when navigation is not collapsed

### DIFF
--- a/assets/gitbook/custom.css
+++ b/assets/gitbook/custom.css
@@ -43,7 +43,7 @@
         width: calc(50% - 3px);
     }
 
-    .book.with-summary .book-body .book-header {
+    .book.with-summary .book-body {
         overflow-x: hidden;
         overflow-y: hidden;
     }


### PR DESCRIPTION
When the navigation is not collapsed and the page width is less than 1240px, the settings dropdown gets hidden behind `.book-body`, leading to this render issue.

<img width='470' height='152' alt="Screenshot of hidden settings" src='https://github.com/user-attachments/assets/9a331f13-233d-43bd-84b7-7a5645df7d02' />

This minimal PR resolves it by omitting `.book-header` from `overflow: hidden`.